### PR TITLE
Allow type as scope

### DIFF
--- a/lib/mongoid/acts_as_list.rb
+++ b/lib/mongoid/acts_as_list.rb
@@ -19,7 +19,13 @@ module ActsAsList
       def acts_as_list(options = {})
         configuration = { :column => 'position' }
         configuration.update(options) if options.is_a?(Hash)
-        configuration[:scope] = "#{configuration[:scope]}_id".intern if configuration[:scope].is_a?(Symbol) && configuration[:scope].to_s !~ /_id$/
+        if configuration[:scope].is_a?(Symbol)
+          if configuration[:scope].to_s == "_type"
+            configuration[:scope] = "#{configuration[:scope]}".intern
+          elsif configuration[:scope].to_s !~ /_id$/
+            configuration[:scope] = "#{configuration[:scope]}_id".intern
+          end
+        end
 
         define_method :position_column do
           configuration[:column].to_s

--- a/spec/acts_as_list/embedded_item_spec.rb
+++ b/spec/acts_as_list/embedded_item_spec.rb
@@ -122,7 +122,7 @@ describe 'ActsAsList for Mongoid' do
       end
 
       it "items[2].move(:to => 3) should move item 2 to position 3" do
-        @list.items.where(:number => 2).first.move(:to => 3
+        @list.items.where(:number => 2).first.move(:to => 3)
         get_positions(@list).should == [1, 3, 2, 4]
       end
 


### PR DESCRIPTION
I needed to be able to use the _type column as scope to give each class in an STI table it's own acts_as_list scope, which this patch enables.
