### PR TITLE
update_attributes and save! prevents mongoid to identify previous_changes

### DIFF
--- a/lib/mongoid/acts_as_list.rb
+++ b/lib/mongoid/acts_as_list.rb
@@ -401,8 +401,7 @@ module ActsAsList
 
       def set_my_position new_position
         if new_position != my_position
-          self.update_attributes position_column => new_position
-          save!
+          self.update_attributes! position_column => new_position
         end
       end
 


### PR DESCRIPTION
I have made changes to the lib/mongoid/acts_as_list.rb by replacing update_attributes with update_attributes!. The reason for this change is update_attributes in turn calls save. Having update_attributes and then save!, causes mongoid.previous_changes to return empty. So replacing update_attributes and save!, with single update_attributes! is equivalent and mongoid.previous_changes works.
