### PR TITLE
Overwrites default comparison operator to delegate to position's value

### DIFF
--- a/lib/mongoid/acts_as_list.rb
+++ b/lib/mongoid/acts_as_list.rb
@@ -420,6 +420,11 @@ module ActsAsList
         false
       end
 
+      # Overwrites default comparer to return comparison index value based on defined position
+      def <=>(other)
+        self[position_column] <=> other[position_column]
+      end
+
       def position_key
         position_column.to_sym
       end

--- a/spec/acts_as_list/embedded_item_spec.rb
+++ b/spec/acts_as_list/embedded_item_spec.rb
@@ -21,7 +21,7 @@ describe 'ActsAsList for Mongoid' do
   end
 
   def get_positions list
-    list.items.sort { |x,y| x.my_position <=> y.my_position }.map(&:number)
+    list.items.sort.map(&:number)
   end
 
   context "4 list items (1,2,3,4) that have parent_id pointing to first list container"  do

--- a/spec/acts_as_list/referenced_category_spec.rb
+++ b/spec/acts_as_list/referenced_category_spec.rb
@@ -21,7 +21,7 @@ describe 'ActsAsList for Mongoid' do
   end
 
   def get_positions(category)
-    category.reload.categories.sort { |x,y| x.my_position <=> y.my_position }.map(&:number)
+    category.reload.categories.sort.map(&:number)
   end
 
   context "4 category categories (1,2,3,4) that have parent_id pointing to first category container" do


### PR DESCRIPTION
First thing that i've noticed when downloaded the Gem was that the default ".sort" method on collection was not returning list values order based on position_column defined.

IMHO, this should be the default behavior of any collection that implements act_as_list's behaviour.

Regards!
