### PR TITLE
Allow usage of Mongoid prior to version 3.0

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,0 +1,1 @@
+rvm use --create 1.9.3@act_as_list_mongoid

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,17 @@
 source :rubygems
 
-gem 'mongoid',                  '>= 3.0.0'
+gem 'mongoid',                  '>= 2.4.12'
 gem "mongoid_embedded_helper",  '>= 0.2.5'
 
 group :test, :development do
   gem "cutter",   ">= 0"
   gem "shoulda",  ">= 0"
   gem "rspec",    ">= 2.5"
+  gem 'bson_ext', '>= 1.5.1'
 end
 
 group :development do
-  gem "bundler",  ">= 1.0.10"
-  gem "jeweler",  ">= 1.6.4"
-  gem "simplecov",     ">= 0"
+  gem "bundler",   ">= 1.0.10"
+  gem "jeweler",   ">= 1.6.4"
+  gem "simplecov", ">= 0"
 end

--- a/acts_as_list_mongoid.gemspec
+++ b/acts_as_list_mongoid.gemspec
@@ -43,26 +43,28 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<mongoid>, [">= 3.0.0"])
+      s.add_runtime_dependency(%q<mongoid>, [">= 2.0.1"])
       s.add_runtime_dependency(%q<mongoid_embedded_helper>, [">= 0.2.5"])
       s.add_development_dependency(%q<cutter>, [">= 0"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])
       s.add_development_dependency(%q<rspec>, [">= 2.5"])
       s.add_development_dependency(%q<bundler>, [">= 1.0.10"])
+      s.add_development_dependency(%q<bson_ext>, [">= 1.5.1"])
       s.add_development_dependency(%q<jeweler>, [">= 1.6.4"])
       s.add_development_dependency(%q<simplecov>, [">= 0"])
     else
-      s.add_dependency(%q<mongoid>, [">= 3.0.0"])
+      s.add_dependency(%q<mongoid>, [">= 2.0.1"])
       s.add_dependency(%q<mongoid_embedded_helper>, [">= 0.2.5"])
       s.add_dependency(%q<cutter>, [">= 0"])
       s.add_dependency(%q<shoulda>, [">= 0"])
-      s.add_dependency(%q<rspec>, [">= 2.5"])
+      s.add_dependency(%q<rspec>, [">= 2.5"])      
       s.add_dependency(%q<bundler>, [">= 1.0.10"])
       s.add_dependency(%q<jeweler>, [">= 1.6.4"])
       s.add_dependency(%q<simplecov>, [">= 0"])
+      s.add_dependency(%q<bson_ext>, [">= 1.5.1"])
     end
   else
-    s.add_dependency(%q<mongoid>, [">= 3.0.0"])
+    s.add_dependency(%q<mongoid>, [">= 2.0.1"])
     s.add_dependency(%q<mongoid_embedded_helper>, [">= 0.2.5"])
     s.add_dependency(%q<cutter>, [">= 0"])
     s.add_dependency(%q<shoulda>, [">= 0"])
@@ -70,6 +72,7 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<bundler>, [">= 1.0.10"])
     s.add_dependency(%q<jeweler>, [">= 1.6.4"])
     s.add_dependency(%q<simplecov>, [">= 0"])
+    s.add_dependency(%q<bson_ext>, [">= 1.5.1"])
   end
 end
 

--- a/lib/mongoid_helper.rb
+++ b/lib/mongoid_helper.rb
@@ -1,0 +1,25 @@
+class MongoidHelper
+  def self.init_mongoid_config!
+    if is_mongoid_version_lower_than_3?
+      Mongoid.configure.master = Mongo::Connection.new.db('acts_as_list_test')
+    else
+      Mongoid.load! "#{File.dirname(__FILE__)}/../mongoid.yml"
+    end   
+  end
+  
+  def self.clear_collections
+    # for mongo_id 2.x.x purposes
+    if is_mongoid_version_lower_than_3?
+      Mongoid.database.collections.each do |coll|
+        coll.remove
+      end      
+    else
+      List.mongo_session.drop
+    end
+  end
+  
+  private
+  def self.is_mongoid_version_lower_than_3?
+    Gem.loaded_specs["mongoid"].version.to_s < "3.0.0"
+  end
+end

--- a/spec/acts_as_list/embedded_item_spec.rb
+++ b/spec/acts_as_list/embedded_item_spec.rb
@@ -17,7 +17,7 @@ describe 'ActsAsList for Mongoid' do
   end
 
   after :each do
-    List.mongo_session.drop
+    MongoidHelper.clear_collections
   end
 
   def get_positions list

--- a/spec/acts_as_list/referenced_category_spec.rb
+++ b/spec/acts_as_list/referenced_category_spec.rb
@@ -17,7 +17,7 @@ describe 'ActsAsList for Mongoid' do
   end
 
   after :each do
-    Category.mongo_session.drop
+    MongoidHelper.clear_collections
   end
 
   def get_positions(category)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,12 +7,10 @@ require 'rspec'
 require 'rspec/autorun'
 require 'mongoid'
 require 'mongoid_embedded_helper'
-# require 'mongoid_adjust'
 require 'acts_as_list_mongoid'
-
+require 'mongoid_helper'
 
 $:.unshift "#{File.dirname(__FILE__)}/../model/"
 ENV["MONGOID_ENV"]="test"
-Mongoid.load! "#{File.dirname(__FILE__)}/../mongoid.yml"
 
-
+MongoidHelper.init_mongoid_config!


### PR DESCRIPTION
Hi.

Since on our project we're using Mongoid 2.4, we're having problems with current version gem's requirement of mongoid 3.0.
I've noticed that Mongoid 2.0 was allowed on a prior version of the gem, so i have created a class to help dealing with different requirements amongst different versions of mongoid and delegated the logics of interaction with mongoid that along with the versions to that class.

I've also included a default .rvmrc file to load a preset env case dev is using rvm to control versioning of ruby and gems.
